### PR TITLE
Safeguard against user error in defaults.yaml

### DIFF
--- a/colcon_recursive_crawl/package_discovery/recursive_crawl.py
+++ b/colcon_recursive_crawl/package_discovery/recursive_crawl.py
@@ -44,6 +44,10 @@ class RecursiveDiscoveryExtension(PackageDiscoveryExtensionPoint):
         if args.base_paths is None:
             return set()
 
+        if isinstance(args.base_paths, str):
+            raise ValueError('Base paths should be a sequence of strings, '
+                             'not a string')
+
         logger.info(
             'Crawling recursively for packages in %s',
             ', '.join([
@@ -52,6 +56,7 @@ class RecursiveDiscoveryExtension(PackageDiscoveryExtensionPoint):
 
         visited_paths = set()
         descs = set()
+
         for base_path in args.base_paths:
             for dirpath, dirnames, filenames in os.walk(
                 base_path, followlinks=True,


### PR DESCRIPTION
If you set base-paths: my/src/dir in defaults.yaml, package discovery will search for packages 'm', 'y', '/', ... and spit out a ton of errors.
This makes that mistake obvious.
