### PR TITLE
Manually expand shell wildcards in --base-paths

### DIFF
--- a/colcon_recursive_crawl/package_discovery/recursive_crawl.py
+++ b/colcon_recursive_crawl/package_discovery/recursive_crawl.py
@@ -5,6 +5,7 @@ import os
 
 from colcon_core.argument_default import is_default_value
 from colcon_core.argument_default import wrap_default_value
+from colcon_core.package_discovery import expand_wildcards
 from colcon_core.package_discovery import logger
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
 from colcon_core.package_identification import identify
@@ -43,6 +44,10 @@ class RecursiveDiscoveryExtension(PackageDiscoveryExtensionPoint):
     def discover(self, *, args, identification_extensions):  # noqa: D102
         if args.base_paths is None:
             return set()
+
+        # manually check for wildcards and expand them in case
+        # the values were not provided through the shell
+        expand_wildcards(args.base_paths)
 
         logger.info(
             'Crawling recursively for packages in %s',

--- a/colcon_recursive_crawl/package_discovery/recursive_crawl.py
+++ b/colcon_recursive_crawl/package_discovery/recursive_crawl.py
@@ -5,7 +5,7 @@ import os
 
 from colcon_core.argument_default import is_default_value
 from colcon_core.argument_default import wrap_default_value
-from colcon_core.package_discovery import expand_wildcards
+from colcon_core.package_discovery import expand_dir_wildcards
 from colcon_core.package_discovery import logger
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
 from colcon_core.package_identification import identify
@@ -47,7 +47,7 @@ class RecursiveDiscoveryExtension(PackageDiscoveryExtensionPoint):
 
         # manually check for wildcards and expand them in case
         # the values were not provided through the shell
-        expand_wildcards(args.base_paths)
+        expand_dir_wildcards(args.base_paths)
 
         logger.info(
             'Crawling recursively for packages in %s',

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core>=0.6.2
+  colcon-core>=0.7.0
 packages = find:
 zip_safe = true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core>=0.5.0
+  colcon-core>=0.6.2
 packages = find:
 zip_safe = true
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-recursive-crawl]
 No-Python2:
-Depends3: python3-colcon-core (>= 0.5.0)
+Depends3: python3-colcon-core (>= 0.6.2)
 Suite: bionic focal jammy stretch buster bullseye
 X-Python3-Version: >= 3.5

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-recursive-crawl]
 No-Python2:
-Depends3: python3-colcon-core (>= 0.6.2)
+Depends3: python3-colcon-core (>= 0.7.0)
 Suite: bionic focal jammy stretch buster bullseye
 X-Python3-Version: >= 3.5

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -11,3 +11,4 @@ recrawling
 scspell
 setuptools
 thomas
+wildcards


### PR DESCRIPTION
Requires https://github.com/colcon/colcon-core/pull/439

Fixes/relates to https://github.com/colcon/colcon-core/issues/438

This manually expands shell wildcards for `--base-paths` in case the value was provided through a `defaults.yaml` file (or any other way which doesn't automatically expand them, like on Windows).

I updated the minimum `colcon-core` version to `0.7.0` assuming that https://github.com/colcon/colcon-core/pull/439 is going to end up in `colcon-core==0.7.0`. If it doesn't, this will need to be changed.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>